### PR TITLE
Cross-app session linking: getSessionHeaders() + x-shipbook-session ingestion

### DIFF
--- a/packages/client/src/models/api-responses.ts
+++ b/packages/client/src/models/api-responses.ts
@@ -7,6 +7,7 @@ export interface LoginResponse {
   token: string;
   config: ConfigResponse;
   sessionUrl: string;
+  sessionId?: string; // Absent on older servers; empty when the device is silenced
 }
 
 /**

--- a/packages/client/src/session-manager.ts
+++ b/packages/client/src/session-manager.ts
@@ -9,7 +9,8 @@ import {
   appenderFactory,
   Exception,
   AppEvent,
-  CORE_VERSION
+  CORE_VERSION,
+  SESSION_LINK_HEADER
 } from '@shipbook/core';
 import type {
   User,
@@ -56,6 +57,7 @@ const defaultConfig: ConfigResponse = {
 
 class SessionManager {
   token?: string;
+  sessionId?: string;
   private _loginObj?: Login;
   user?: User;
   appId?: string;
@@ -147,6 +149,7 @@ class SessionManager {
 
     this.isInLoginRequest = true;
     this.token = undefined;
+    this.sessionId = undefined;
 
     try {
       const loginObj = await this.loginObj.getObj();
@@ -157,6 +160,7 @@ class SessionManager {
         const json = await resp.json() as LoginResponse;
         InnerLog.i('Succeeded! : ' + JSON.stringify(json));
         this.token = json.token;
+        this.sessionId = json.sessionId;
 
         // Set config information
         this.readConfig(json.config);
@@ -281,6 +285,12 @@ class SessionManager {
 
   getUUID(): string | undefined {
     return this.loginObj?.udid;
+  }
+
+  // Empty until login completes (or on older servers that don't return sessionId), so callers can always spread it.
+  getSessionHeaders(): Record<string, string> {
+    if (!this.sessionId || !this.appId) return {};
+    return { [SESSION_LINK_HEADER]: `${this.appId}:${this.sessionId}` };
   }
 }
 

--- a/packages/client/src/shipbook.ts
+++ b/packages/client/src/shipbook.ts
@@ -133,4 +133,12 @@ export default class Shipbook {
   static getUUID(): string | undefined {
     return sessionManager.getUUID();
   }
+
+  /**
+   * Headers to attach to requests toward your own backend so its Shipbook sessions
+   * link back to this app session ({} until login completes).
+   */
+  static getSessionHeaders(): Record<string, string> {
+    return sessionManager.getSessionHeaders();
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,9 @@ export {
   StackTraceElement,
   Severity,
   SeverityUtil,
-  Platform
+  Platform,
+  SESSION_LINK_HEADER,
+  parseSessionLinkHeader
 } from './models';
 
 export type {
@@ -35,6 +37,7 @@ export type {
   RootResponse,
   RequestContext,
   Session,
+  SessionLink,
   Browser,
   DeviceInfo,
   VersionInfo,

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -15,10 +15,11 @@ export type {
 } from './config-response';
 export type { RequestContext } from './request-context';
 
-export { Platform } from './session';
+export { Platform, SESSION_LINK_HEADER, parseSessionLinkHeader } from './session';
 
 export type {
   Session,
+  SessionLink,
   Browser,
   DeviceInfo,
   VersionInfo,

--- a/packages/core/src/models/request-context.ts
+++ b/packages/core/src/models/request-context.ts
@@ -1,4 +1,5 @@
 import type User from './user';
+import type { SessionLink } from './session';
 
 /**
  * Context for a request or background job.
@@ -7,6 +8,7 @@ import type User from './user';
 export interface RequestContext {
   sessionId: string;       // express-session ID, job ID, or generated UUID
   traceId?: string;        // Optional - only for HTTP requests (x-request-id)
+  callerSession?: SessionLink;  // Cross-app link from the x-shipbook-session header
   user?: User;             // Full user object (userId, userName, email, etc.)
   metadata?: Record<string, unknown>;  // method, path, ip, etc.
   startTime: Date;

--- a/packages/core/src/models/session.ts
+++ b/packages/core/src/models/session.ts
@@ -106,6 +106,8 @@ export interface Session {
   metadata?: Record<string, unknown>;
   isBackground?: boolean;
   jobName?: string;
+  callerApp?: string;
+  callerSessionId?: string;
   deviceInfo: DeviceInfo;
   time: string;  // ISO string, server parses as Date
   deviceTime?: string;  // ISO string, server parses as Date
@@ -117,5 +119,21 @@ export interface Session {
   os: OsInfo;
   userInfo?: User;
   logs?: BaseLog[];
+}
+
+// Cross-app session link: a client SDK sends "<appId>:<sessionId>" on its backend requests so
+// the receiving server's sessions record which app session's request created them.
+export const SESSION_LINK_HEADER = 'x-shipbook-session';
+
+export interface SessionLink {
+  appId: string;
+  sessionId: string;
+}
+
+export function parseSessionLinkHeader(value?: string): SessionLink | undefined {
+  if (!value) return undefined;
+  const idx = value.indexOf(':');
+  if (idx < 1 || idx === value.length - 1) return undefined;
+  return { appId: value.slice(0, idx), sessionId: value.slice(idx + 1) };
 }
 

--- a/packages/core/test/session-link.test.ts
+++ b/packages/core/test/session-link.test.ts
@@ -1,0 +1,19 @@
+import { parseSessionLinkHeader } from '../src/models/session';
+
+describe('parseSessionLinkHeader', () => {
+  it('parses appId and sessionId', () => {
+    expect(parseSessionLinkHeader('app-1:sess-abc')).toEqual({ appId: 'app-1', sessionId: 'sess-abc' });
+  });
+
+  it('splits on the first colon only', () => {
+    expect(parseSessionLinkHeader('app:sess:extra')).toEqual({ appId: 'app', sessionId: 'sess:extra' });
+  });
+
+  it('returns undefined for undefined, empty, or malformed values', () => {
+    expect(parseSessionLinkHeader(undefined)).toBeUndefined();
+    expect(parseSessionLinkHeader('')).toBeUndefined();
+    expect(parseSessionLinkHeader('no-separator')).toBeUndefined();
+    expect(parseSessionLinkHeader(':sess')).toBeUndefined();
+    expect(parseSessionLinkHeader('app:')).toBeUndefined();
+  });
+});

--- a/packages/node/src/appender/sbcloud-appender.ts
+++ b/packages/node/src/appender/sbcloud-appender.ts
@@ -116,6 +116,8 @@ export class SBCloudAppender implements BaseAppender {
       metadata: ctx.metadata || { type: 'background' },
       isBackground: ctx.isBackground ?? true,
       jobName: ctx.jobName,
+      callerApp: ctx.callerSession?.appId,
+      callerSessionId: ctx.callerSession?.sessionId,
       time: ctx.startTime.toISOString(),
       platform: Platform.NODE,
       deviceInfo: this.deviceInfo,

--- a/packages/node/src/context/request-context.ts
+++ b/packages/node/src/context/request-context.ts
@@ -15,6 +15,7 @@ export class RequestContextManager {
     const fullContext: RequestContext = {
       sessionId: context.sessionId || randomUUID(),
       traceId: context.traceId,  // Only set if provided (from x-request-id header)
+      callerSession: context.callerSession,
       user: context.user,
       metadata: context.metadata,
       startTime: new Date(),

--- a/packages/node/src/middleware/express.ts
+++ b/packages/node/src/middleware/express.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import type { User, RequestContext } from '@shipbook/core';
-import { logManager } from '@shipbook/core';
+import { logManager, parseSessionLinkHeader, SESSION_LINK_HEADER } from '@shipbook/core';
 import { requestContext } from '../context/request-context';
 
 export interface ExpressExtractors {
@@ -37,6 +37,7 @@ export function createExpressMiddleware(extractors: ExpressExtractors = {}) {
     const context: RequestContext = {
       sessionId: merged.session?.(req) || randomUUID(),
       traceId: merged.trace?.(req),
+      callerSession: parseSessionLinkHeader(req.headers[SESSION_LINK_HEADER] as string | undefined),
       user: merged.user?.(req),
       metadata: {
         method: req.method,

--- a/packages/node/src/middleware/nestjs.ts
+++ b/packages/node/src/middleware/nestjs.ts
@@ -2,7 +2,7 @@ import type { NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/com
 import type { Observable } from 'rxjs';
 import { randomUUID } from 'crypto';
 import type { User, RequestContext } from '@shipbook/core';
-import { logManager } from '@shipbook/core';
+import { logManager, parseSessionLinkHeader, SESSION_LINK_HEADER } from '@shipbook/core';
 import { requestContext } from '../context/request-context';
 
 export interface NestExtractors {
@@ -25,6 +25,7 @@ export function createNestInterceptor(extractors: NestExtractors = {}) {
       const ctx: RequestContext = {
         sessionId: extractors.session?.(context) || req.sessionID || randomUUID(),
         traceId: extractors.trace?.(context) || req.headers['x-request-id'],
+        callerSession: parseSessionLinkHeader(req.headers[SESSION_LINK_HEADER]),
         user,
         metadata: {
           method: req.method,

--- a/packages/node/test/express-middleware.test.ts
+++ b/packages/node/test/express-middleware.test.ts
@@ -96,6 +96,33 @@ describe('Express Middleware', () => {
       });
     });
 
+    it('should extract callerSession from x-shipbook-session header', (done) => {
+      const middleware = createExpressMiddleware();
+      const req = createMockRequest({
+        headers: { 'x-shipbook-session': 'app-1:sess-abc' }
+      });
+      const res = createMockResponse();
+
+      middleware(req, res, () => {
+        const ctx = requestContext.get();
+        expect(ctx?.callerSession).toEqual({ appId: 'app-1', sessionId: 'sess-abc' });
+        done();
+      });
+    });
+
+    it('should ignore a malformed x-shipbook-session header', (done) => {
+      const middleware = createExpressMiddleware();
+      const req = createMockRequest({
+        headers: { 'x-shipbook-session': 'no-separator' }
+      });
+      const res = createMockResponse();
+
+      middleware(req, res, () => {
+        expect(requestContext.get()?.callerSession).toBeUndefined();
+        done();
+      });
+    });
+
     it('should extract sessionId from express-session', (done) => {
       const middleware = createExpressMiddleware();
       const req = createMockRequest();

--- a/packages/node/test/sbcloud-appender.test.ts
+++ b/packages/node/test/sbcloud-appender.test.ts
@@ -234,6 +234,21 @@ describe('SBCloudAppender', () => {
       expect(sessions[0].logs[0].message).toBe('real log');
     });
 
+    it('stamps callerApp/callerSessionId from the context onto the session', async () => {
+      await appender.ensureSession({
+        sessionId: 'linked-session',
+        startTime: new Date(),
+        isBackground: false,
+        callerSession: { appId: 'client-app', sessionId: 'client-sess' }
+      });
+      appender.flush();
+      await tick();
+
+      const sessions = (requestSpy.mock.calls[0][1] as { sessions: any[] }).sessions;
+      expect(sessions[0].callerApp).toBe('client-app');
+      expect(sessions[0].callerSessionId).toBe('client-sess');
+    });
+
     it('attaches stub alongside other sessions with logs in the same ingest', async () => {
       // Use Info (below default flushSeverity) so the push doesn't trigger an immediate
       // flush; otherwise the has-log session would ship before ensureSession() runs.


### PR DESCRIPTION
Part of the cross-app session linking feature (plan: `plan/cross-app-session-linking.md`, Phase 1) — same branch in Server, Console, and Doc. Merge after the Server PR.

## What
- **core**: `callerApp`/`callerSessionId` on `Session`, `callerSession` on `RequestContext`, plus the shared `SESSION_LINK_HEADER` constant (`x-shipbook-session`) and `parseSessionLinkHeader()` — a real trust boundary, so malformed header values are ignored
- **client** (covers browser + react-native): stores `sessionId` from the login response; new `Shipbook.getSessionHeaders()` returns `{ 'x-shipbook-session': '<appId>:<sessionId>' }` for the app to attach to its own backend requests — `{}` until login completes or on older servers, so spreading it is always safe
- **node**: the Express middleware and NestJS interceptor parse the header into the request context next to the existing traceId extraction; the cloud appender stamps the caller fields onto each emitted session. `RequestContextManager.run` rebuilds the context field-by-field, so the new field is threaded there too (caught by test — it silently dropped the field otherwise).

Backward compatible in both directions: old server + new SDK → `getSessionHeaders()` returns `{}`; new server + old SDK → no header, no link.

## Verification
- `npm run build` (core → client → workspaces) clean
- `npm run test`: 81 passing across packages, including new tests for header parsing (valid / first-colon split / malformed), middleware extraction + malformed-header ignore, and appender stamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs
- Server: ShipBook/server#10
- Console: ShipBook/console#6
- Docs: ShipBook/Doc#2
